### PR TITLE
Make second assignee section more obvious

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@
 
 # Related issue(s)
 
-<!--- Paste a link to the Salesforce work task or tasks that this PR closes here -->
+<!--- Paste a link to the Jira issue or tasks that this PR closes here -->
 
 - [[BUGSNAG ISSUE]](link_to_bugsnag_issue)
 - [[TICKET_NUMBER]](link_to_aa_url)
@@ -28,9 +28,10 @@
 
 ## Assignee
 
-The author of the PR must be one assignee
+The author of the PR (the person who wrote the code) must be one assignee
 
-The person who has tested this in staging, is the second assignee
+The person who has tested this in staging, is the second assignee.
+This person assigns themselves, when they are going to test this on staging, as part of the review phase of a ticket's lifecycle.
 
 # Screenshots
 
@@ -43,7 +44,7 @@ The person who has tested this in staging, is the second assignee
 
 - [ ] The implementation has been tested locally
 - [ ] The author of this PR is the Assignee
-- [ ] The implementation has been tested in staging (and the person who is doing it is an assignee)
+- [ ] The implementation has been tested in staging (and the person (who is not the author) doing it is an assignee of this PR)
   - [ ] This cannot be tested on staging, and the reasons why are in the `How to test / reproduce` section
 - [ ] There are no typos, spelling, or grammatical errors in end-user facing text
 - [ ] The Pull Request is tagged with the `staging` label if it is deployed to staging


### PR DESCRIPTION
Attempt to make checklist item clearer

<!--- Provide a general summary of your changes in the Title above -->

# Related issue(s)

<!--- Paste a link to the Salesforce work task or tasks that this PR closes here -->

- [[Retro item]](https://agilesuite.io/retrospective/board-actions?id=142)

# Description

Adds words around the checklist

# Post-deployment steps

<!--- If data needs to be migrated or any rake tasks should be executed after deploy, note what to do here -->

# Type of Change
<!--- Check the box(es) that your changes address -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Maintenance task (rake tasks or changes that do not change logic tha will affect the application behaviour)

# How to test / reproduce

Not able to be tested unfortunately.

## Assignee

The author of the PR must be one assignee

The person who has tested this in staging, is the second assignee

# Screenshots

<!--- If appropriate.
      Protip: You can click and drag files into the pull request page to upload
      Optionally: A link to mockups (if they exist).
  -->

# Checklist

- [ ] The implementation has been tested locally
- [X] The author of this PR is the Assignee
- [ ] The implementation has been tested in staging (and the person who is doing it is an assignee)
  - [ ] This cannot be tested on staging, and the reasons why are in the `How to test / reproduce` section
- [ ] There are no typos, spelling, or grammatical errors in end-user facing text
- [ ] The Pull Request is tagged with the `staging` label if it is deployed to staging
- [ ] Tests are added where appropriate
- [X] The client/support team have been notified before release, if this change runs migrations or other risky code
