### PR TITLE
[PLAN-1377] chore: update pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,53 +1,53 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!-- Add a short yet descriptive title above -->
 
-# Related issue(s)
+## Related issues
 
-<!--- Paste a link to the Jira issue or tasks that this PR closes here -->
+<!-- Link to Jira issues or Bugsnag errors -->
 
-- [[BUGSNAG ISSUE]](link_to_bugsnag_issue)
-- [[TICKET_NUMBER]](link_to_aa_url)
+- [KEY-123](https://netengine-trial.atlassian.net/browse/:id)
+- [Bugsnag error](https://app.bugsnag.com/netengine/scout-recruit/errors/:id)
 
-# Description
+## Description
 
-<!--- Describe your changes in detail
-        for example: what is the current behavior and what is the new behavior-->
+<!-- Short summary of changes -->
 
-# Post-deployment steps
+## Pre-deployment steps
 
-<!--- If data needs to be migrated or any rake tasks should be executed after deploy, note what to do here -->
+<!-- Describe any steps that must be performed BEFORE the deployment; e.g.: change configuration values -->
 
-# Type of Change
-<!--- Check the box(es) that your changes address -->
+## Post-deployment steps
 
-- [ ] Request (code for a specific purpose that will not add a feature. e.g. one off rake task)
+<!-- Describe any steps that must be performed AFTER the deployment; e.g.: run a Rake task -->
+
+## Type of change
+
+<!-- Select one or multiple options -->
+
+- [ ] Request (code for a specific purpose that will not add a feature. e.g. one off Rake task)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Maintenance task (rake tasks or changes that do not change logic tha will affect the application behaviour)
+- [ ] Maintenance task (Rake tasks or changes that do not change logic that will affect the application behaviour)
 
-# How to test / reproduce
+## How to test
+
+<!-- Describe the steps to test the changes that this PR introduces; or explain the reason why it is not possible to test the changes -->
 
 ## Assignee
 
-The author of the PR (the person who wrote the code) must be one assignee
+<!-- Add mentions to the PR author and also to reviewers who tested the changes in UAT -->
 
-The person who has tested this in staging, is the second assignee.
-This person assigns themselves, when they are going to test this on staging, as part of the review phase of a ticket's lifecycle.
+## Screenshots
 
-# Screenshots
+<!-- Add screenshots, link to Loom videos, or link to wireframes/mockups if they are relevant; e.g.: for frontend work -->
 
-<!--- If appropriate.
-      Protip: You can click and drag files into the pull request page to upload
-      Optionally: A link to mockups (if they exist).
-  -->
+## Checklist
 
-# Checklist
+- [ ] Changes were tested locally by the author
+- [ ] Changes were tested on staging by the author
+- [ ] Changes were tested on staging by reviewers and reviewers mentioned themselves in the "Assignee" section above
+- [ ] Changes were not tested and the reason was explained in the "How to test" section above
+- [ ] There are no typos, spelling, or grammatical errors in UI/UX text
+- [ ] `staging` label was added after this PR was released to staging
+- [ ] Tests were written where appropriate
 
-- [ ] The implementation has been tested locally
-- [ ] The author of this PR is the Assignee
-- [ ] The implementation has been tested in staging (and the person (who is not the author) doing it is an assignee of this PR)
-  - [ ] This cannot be tested on staging, and the reasons why are in the `How to test / reproduce` section
-- [ ] There are no typos, spelling, or grammatical errors in end-user facing text
-- [ ] The Pull Request is tagged with the `staging` label if it is deployed to staging
-- [ ] Tests are added where appropriate
-- [ ] The client/support team have been notified before release, if this change runs migrations or other risky code


### PR DESCRIPTION
## Related issues

- [PLAN-1377](https://netengine-trial.atlassian.net/browse/PLAN-1377)

## Description

This PR updates the existing pull request template for all NetEngine projects to be in line with the changes made to the PR template for :Recruit.

## Pre-deployment steps

N/A

## Post-deployment steps

N/A

## Type of change

- [ ] Request (code for a specific purpose that will not add a feature. e.g. one off Rake task)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Maintenance task (Rake tasks or changes that do not change logic that will affect the application behaviour)

## How to test

N/A

## Assignee

@willrosa-ne

## Screenshots

N/A

## Checklist

- [X] Changes were tested locally by the author
- [ ] Changes were tested on staging by the author
- [ ] Changes were tested on staging by reviewers and reviewers mentioned themselves in the "Assignee" section above
- [ ] Changes were not tested and the reason was explained in the "How to test" section above
- [X] There are no typos, spelling, or grammatical errors in UI/UX text
- [ ] `staging` label was added after this PR was released to staging
- [ ] Tests were written where appropriate